### PR TITLE
Structure data more consistently with normal monolog usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,12 +33,12 @@ use Monolog\Logger;
 $logger = new Logger('dakatsuka');
 $logger->pushHandler(new FluentHandler());
 
-$logger->debug('example.monolog', array('foo' => 'bar'));
-$logger->info('example.fluentd', array('fizz' => 'buzz'));
+$logger->debug('Debug message', array('foo' => 'bar'));
+$logger->info('Something happened', array('fizz' => 'buzz'));
 
 // Fluentd:
-// 2013-10-11 01:00:00 +0900 dakatsuka.example.monolog: {"foo":"bar","level":"DEBUG"}
-// 2013-10-11 01:00:00 +0900 dakatsuka.example.fluentd: {"fizz":"buzz","level":"INFO"}
+// 2013-10-11 01:00:00 +0900 dakatsuka: {"message":"Debug message","level":"DEBUG","context":{"foo":"bar"}}
+// 2013-10-11 01:00:00 +0900 dakatsuka: {"message":"Something happened","level":"INFO","context":{"fizz":"buzz"}}
 ```
 
 You can specify the host name and port.

--- a/src/Dakatsuka/MonologFluentHandler/FluentHandler.php
+++ b/src/Dakatsuka/MonologFluentHandler/FluentHandler.php
@@ -49,9 +49,11 @@ class FluentHandler extends AbstractProcessingHandler
      */
     public function write(array $record)
     {
-        $tag  = $record['channel'] . '.' . $record['message'];
-        $data = $record['context'];
+        $tag  = $record['channel'];
+        $data = array();
         $data['level'] = Logger::getLevelName($record['level']);
+        $data['message'] = $record['message'];
+        $data['context'] = $record['context'];
 
         $this->logger->post($tag, $data);
     }

--- a/tests/Dakatsuka/MonologFluentHandler/FluentHandlerTest.php
+++ b/tests/Dakatsuka/MonologFluentHandler/FluentHandlerTest.php
@@ -27,7 +27,7 @@ class FluentHandlerTest extends \PHPUnit_Framework_TestCase
     public function testWrite()
     {
         $context = $this->record['context'];
-        $context['level'] = Logger::getLevelName($this->record['level']);
+        $level = Logger::getLevelName($this->record['level']);
 
         $loggerMock = $this->getMockBuilder('Fluent\Logger\FluentLogger')
             ->disableOriginalConstructor()
@@ -35,7 +35,7 @@ class FluentHandlerTest extends \PHPUnit_Framework_TestCase
         $loggerMock
             ->expects($this->once())
             ->method('post')
-            ->with('debug.monolog.fluent', $context);
+            ->with('debug', array('message'=>$this->record['message'], 'context'=>$context, 'level'=>$level));
 
         $handler = new FluentHandler($loggerMock);
         $handler->write($this->record);


### PR DESCRIPTION
It is far more normal to use monolog to write messages in sentences, therefor the message should be passed on it's own, rather than being appended to the tag.
[See symfony logging examples](http://symfony.com/doc/current/cookbook/logging/monolog.html)

This is obviously a backwards incompatible change so it would need to be released as 2.0
